### PR TITLE
Scope ClinEpi user dataset help to a project-specific permalink

### DIFF
--- a/content/ClinEpiDB/user_datasets_help.md
+++ b/content/ClinEpiDB/user_datasets_help.md
@@ -1,5 +1,5 @@
 ---
-permalink: /user_datasets_help
+permalink: /ClinEpiDB/user_datasets_help
 title: User Data Sets Help
 ---
 <style>


### PR DESCRIPTION
With this change in place, the ClinEpi UD help page will be served at `{communitySiteUrl}/ClinEpiDB/user_datasets_help.html`.